### PR TITLE
Add sbom_generation file

### DIFF
--- a/sbom_generation.yaml
+++ b/sbom_generation.yaml
@@ -1,0 +1,35 @@
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+
+steps:
+  - type: Command
+    name: "Install cyclonedx_py module"
+    command: |
+      pip install cyclonedx-bom
+  - type: Command
+    name: "Run Python cyclonedx_py module"
+    command: |
+      python3 -m cyclonedx_py -r -i hiq/requirements-fastapi.txt -pb --format json -o fastapi-bom.json
+      python3 -m cyclonedx_py -r -i hiq/requirements-gpu.txt -pb --format json -o gpu-bom.json
+      python3 -m cyclonedx_py -r -i hiq/requirements-int.txt -pb --format json -o int-bom.json
+      python3 -m cyclonedx_py -r -i hiq/requirements-lavis.txt -pb --format json -o lavis-bom.json
+      python3 -m cyclonedx_py -r -i hiq/requirements-nodeps.txt -pb --format json -o nodeps-bom.json
+      python3 -m cyclonedx_py -r -i hiq/requirements-transformers.txt -pb --format json -o transformers-bom.json
+      python3 -m cyclonedx_py -r -i hiq/requirements.txt -pb --format json -o default-bom.json
+  - type: Command
+    name: "Download CycloneDx-cli executable and install dependencies"
+    command: |
+      wget https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+      yum install -y libicu
+  - type: Command
+    name: "Merge multiple SBOMs using CycloneDX-cli"
+    command: |
+      # For more details, visit https://github.com/CycloneDX/cyclonedx-cli/blob/main/README.md
+      chmod +x cyclonedx-linux-x64
+      ./cyclonedx-linux-x64 merge --input-files fastapi-bom.json gpu-bom.json int-bom.json lavis-bom.json nodeps-bom.json transformers-bom.json default-bom.json --output-file merged-bom.json
+outputArtifacts:
+  - name: artifactSBOM
+    type: BINARY
+    location: ${OCI_PRIMARY_SOURCE_DIR}/merged-bom.json

--- a/sbom_generation.yaml
+++ b/sbom_generation.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+
 version: 0.1
 component: build
 timeoutInSeconds: 1000


### PR DESCRIPTION
This PR adds an [OCI DevOps build specification file](https://docs.oracle.com/en-us/iaas/Content/devops/using/build_specs.htm) that generates a Software Bill of Materials (SBOM) of the repository.

This file is needed to run checks for third-party vulnerabilities and business approval according to Oracle’s GitHub policies.

Please approve and merge this PR.

If you have questions, please reach out to the Oracle GitHub team.